### PR TITLE
feat(config): respect CLAUDE_CONFIG_DIR environment variable

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -5,7 +5,16 @@ const path = require('path');
 const os = require('os');
 
 const PLUGIN_NAME = 'hs';
-const CLAUDE_DIR = path.join(os.homedir(), '.claude');
+let CLAUDE_DIR = process.env.CLAUDE_CONFIG_DIR || '';
+if (CLAUDE_DIR === '~') {
+  CLAUDE_DIR = os.homedir();
+} else if (CLAUDE_DIR.startsWith('~/')) {
+  CLAUDE_DIR = path.join(os.homedir(), CLAUDE_DIR.slice(2));
+}
+CLAUDE_DIR = CLAUDE_DIR.replace(/\/+$/, '');
+if (!CLAUDE_DIR) {
+  CLAUDE_DIR = path.join(os.homedir(), '.claude');
+}
 const PLUGINS_DIR = path.join(CLAUDE_DIR, 'plugins');
 const PLUGIN_DIR = path.join(PLUGINS_DIR, PLUGIN_NAME);
 const SKILLS_DIR = path.join(CLAUDE_DIR, 'skills');
@@ -108,7 +117,10 @@ function createSkill() {
   const sourceSkill = path.join(sourceDir, 'skills', PLUGIN_NAME, 'SKILL.md');
 
   if (fs.existsSync(sourceSkill)) {
-    fs.copyFileSync(sourceSkill, path.join(SKILL_DIR, 'SKILL.md'));
+    // Replace hardcoded ~/.claude/plugins/hs/ paths with actual install location
+    let content = fs.readFileSync(sourceSkill, 'utf8');
+    content = content.replace(/~\/\.claude\/plugins\/hs\//g, PLUGIN_DIR + '/');
+    fs.writeFileSync(path.join(SKILL_DIR, 'SKILL.md'), content, 'utf8');
   } else {
     // Fallback: generate a minimal skill file
     const skillContent = `---
@@ -132,11 +144,11 @@ triggers:
 
 When the user invokes \`/hs\` (with optional subcommands), run the appropriate Python command:
 
-- \`/hs\` or \`/hs status\`: \`python ~/.claude/plugins/hs/commands/hs_cmd.py status\`
-- \`/hs on\`: \`python ~/.claude/plugins/hs/commands/hs_cmd.py on\`
-- \`/hs off\`: \`python ~/.claude/plugins/hs/commands/hs_cmd.py off\`
-- \`/hs skip\`: \`python ~/.claude/plugins/hs/commands/hs_cmd.py skip\`
-- \`/hs log\`: \`python ~/.claude/plugins/hs/commands/hs_cmd.py log\`
+- \`/hs\` or \`/hs status\`: \`python ${PLUGIN_DIR}/commands/hs_cmd.py status\`
+- \`/hs on\`: \`python ${PLUGIN_DIR}/commands/hs_cmd.py on\`
+- \`/hs off\`: \`python ${PLUGIN_DIR}/commands/hs_cmd.py off\`
+- \`/hs skip\`: \`python ${PLUGIN_DIR}/commands/hs_cmd.py skip\`
+- \`/hs log\`: \`python ${PLUGIN_DIR}/commands/hs_cmd.py log\`
 `;
     fs.writeFileSync(path.join(SKILL_DIR, 'SKILL.md'), skillContent, 'utf8');
   }
@@ -249,7 +261,7 @@ Features:
 
 Documentation:
   • https://github.com/frmoretto/hardstop
-  • ~/.claude/plugins/hs/README.md
+  • ${PLUGIN_DIR}/README.md
 `);
 }
 
@@ -278,7 +290,7 @@ Usage:
   npx hardstop --help     Show this help
 
 Installation:
-  Installs Hardstop to: ~/.claude/plugins/hs
+  Installs Hardstop to: ${CLAUDE_DIR}/plugins/hs
   Requires: Claude Code installed
 
 More info:

--- a/commands/hs_cmd.py
+++ b/commands/hs_cmd.py
@@ -28,7 +28,8 @@ STATE_DIR = Path.home() / ".hardstop"
 STATE_FILE = STATE_DIR / "state.json"
 SKIP_FILE = STATE_DIR / "skip_next"
 LOG_FILE = STATE_DIR / "audit.log"
-PLUGIN_DIR = Path.home() / ".claude" / "plugins" / "hs"
+# Derive plugin dir from installed location: commands/ -> hs/
+PLUGIN_DIR = Path(__file__).absolute().parent.parent
 
 
 def get_version() -> str:

--- a/hooks/pre_tool_use.py
+++ b/hooks/pre_tool_use.py
@@ -102,14 +102,18 @@ DANGEROUS_PATTERNS = _load_dangerous_patterns()
 
 # Note: Legacy hardcoded patterns removed in v1.4.0 (now in patterns/dangerous_commands.yaml)
 
+# Derive config dir from installed location: hooks/ -> hs/ -> plugins/ -> config dir
+_CLAUDE_DIR = str(Path(__file__).absolute().parent.parent.parent.parent)
+_CLAUDE_DIR_RE = re.escape(_CLAUDE_DIR)
+
 SAFE_PATTERNS = [
     # Hardstop's own operations (must be able to manage itself)
-    r"^python\s+.*[/\\]\.claude[/\\]plugins[/\\]hs[/\\].*\.py(?:\s+.*)?$",
+    rf"^python\s+.*{_CLAUDE_DIR_RE}[/\\]plugins[/\\]hs[/\\].*\.py(?:\s+.*)?$",
     r"^python\s+.*\.hardstop.*$",
     r"^cat\s+.*\.hardstop[/\\].*$",
-    r"^cat\s+.*\.claude[/\\]plugins[/\\]hs[/\\].*$",
+    rf"^cat\s+.*{_CLAUDE_DIR_RE}[/\\]plugins[/\\]hs[/\\].*$",
     r"^rm\s+(-f\s+)?.*\.hardstop[/\\](skip_next|hook_debug\.log)$",
-    r"^grep\s+.*\.claude[/\\]plugins[/\\]hs[/\\].*$",
+    rf"^grep\s+.*{_CLAUDE_DIR_RE}[/\\]plugins[/\\]hs[/\\].*$",
 
     # Read-only operations
     r"^ls(?:\s+.*)?$",

--- a/install.ps1
+++ b/install.ps1
@@ -3,9 +3,10 @@
 
 $ErrorActionPreference = "Stop"
 
-$PluginDest = Join-Path $env:USERPROFILE '.claude\plugins\hs'
-$SkillDest = Join-Path $env:USERPROFILE '.claude\skills\hs'
-$SettingsFile = Join-Path $env:USERPROFILE '.claude\settings.json'
+$ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR.TrimEnd('\', '/') } else { Join-Path $env:USERPROFILE '.claude' }
+$PluginDest = Join-Path $ClaudeDir 'plugins\hs'
+$SkillDest = Join-Path $ClaudeDir 'skills\hs'
+$SettingsFile = Join-Path $ClaudeDir 'settings.json'
 $Source = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 Write-Host "=== Hardstop Installer ===" -ForegroundColor Cyan
@@ -25,7 +26,7 @@ if (-not (Test-Path $SkillDest)) {
     New-Item -ItemType Directory -Force -Path $SkillDest | Out-Null
 }
 
-$SkillContent = @'
+$SkillContent = @"
 ---
 name: hs
 version: 1.0.0
@@ -47,14 +48,14 @@ triggers:
 
 **Purpose:** Control the Hardstop pre-execution safety layer that blocks dangerous shell commands.
 
-When the user invokes `/hs` (with optional subcommands), run the appropriate Python command:
+When the user invokes ``/hs`` (with optional subcommands), run the appropriate Python command:
 
-- `/hs` or `/hs status`: `python ~/.claude/plugins/hs/commands/hs_cmd.py status`
-- `/hs on`: `python ~/.claude/plugins/hs/commands/hs_cmd.py on`
-- `/hs off`: `python ~/.claude/plugins/hs/commands/hs_cmd.py off`
-- `/hs skip`: `python ~/.claude/plugins/hs/commands/hs_cmd.py skip`
-- `/hs log`: `python ~/.claude/plugins/hs/commands/hs_cmd.py log`
-'@
+- ``/hs`` or ``/hs status``: ``python $PluginDest/commands/hs_cmd.py status``
+- ``/hs on``: ``python $PluginDest/commands/hs_cmd.py on``
+- ``/hs off``: ``python $PluginDest/commands/hs_cmd.py off``
+- ``/hs skip``: ``python $PluginDest/commands/hs_cmd.py skip``
+- ``/hs log``: ``python $PluginDest/commands/hs_cmd.py log``
+"@
 
 $SkillContent | Out-File -FilePath (Join-Path $SkillDest "SKILL.md") -Encoding utf8
 Write-Host "      Skill created." -ForegroundColor Green
@@ -62,8 +63,7 @@ Write-Host "      Skill created." -ForegroundColor Green
 # Step 3: Add hooks to settings.json
 Write-Host "[3/3] Configuring hooks in: $SettingsFile"
 
-# Ensure .claude directory exists
-$ClaudeDir = Split-Path $SettingsFile
+# Ensure config directory exists
 if (-not (Test-Path $ClaudeDir)) {
     New-Item -ItemType Directory -Force -Path $ClaudeDir | Out-Null
 }
@@ -83,6 +83,7 @@ import json
 import sys
 
 settings_file = sys.argv[1]
+plugin_dest = sys.argv[2]
 
 try:
     with open(settings_file, 'r', encoding='utf-8-sig') as f:
@@ -97,7 +98,7 @@ if 'PreToolUse' not in settings['hooks']:
     settings['hooks']['PreToolUse'] = []
 
 import os
-hook_base = os.path.join(os.path.expanduser('~'), '.claude', 'plugins', 'hs', 'hooks')
+hook_base = os.path.join(plugin_dest, 'hooks')
 bash_hook = os.path.join(hook_base, 'pre_tool_use.py').replace('\\', '/')
 read_hook = os.path.join(hook_base, 'pre_read.py').replace('\\', '/')
 
@@ -123,7 +124,7 @@ settings['hooks']['PreToolUse'].append({
 with open(settings_file, 'w', encoding='utf-8') as f:
     json.dump(settings, f, indent=2)
 "@
-        $pythonScript | python - "$SettingsFile"
+        $pythonScript | python - "$SettingsFile" "$PluginDest"
         if ($LASTEXITCODE -eq 0) {
             Write-Host "      Hooks configured (Bash + Read)." -ForegroundColor Green
         } else {
@@ -138,7 +139,8 @@ import os
 import sys
 
 settings_file = sys.argv[1]
-hook_base = os.path.join(os.path.expanduser('~'), '.claude', 'plugins', 'hs', 'hooks')
+plugin_dest = sys.argv[2]
+hook_base = os.path.join(plugin_dest, 'hooks')
 bash_hook = os.path.join(hook_base, 'pre_tool_use.py').replace('\\', '/')
 read_hook = os.path.join(hook_base, 'pre_read.py').replace('\\', '/')
 
@@ -168,7 +170,7 @@ settings = {
 with open(settings_file, 'w', encoding='utf-8') as f:
     json.dump(settings, f, indent=2)
 "@
-    $pythonScript | python - "$SettingsFile"
+    $pythonScript | python - "$SettingsFile" "$PluginDest"
     if ($LASTEXITCODE -eq 0) {
         Write-Host "      Settings created with hooks (Bash + Read)." -ForegroundColor Green
     } else {

--- a/install.sh
+++ b/install.sh
@@ -4,9 +4,11 @@
 
 set -e
 
-PLUGIN_DEST="$HOME/.claude/plugins/hs"
-SKILL_DEST="$HOME/.claude/skills/hs"
-SETTINGS_FILE="$HOME/.claude/settings.json"
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+CLAUDE_DIR="${CLAUDE_DIR%/}"
+PLUGIN_DEST="$CLAUDE_DIR/plugins/hs"
+SKILL_DEST="$CLAUDE_DIR/skills/hs"
+SETTINGS_FILE="$CLAUDE_DIR/settings.json"
 SOURCE="$(cd "$(dirname "$0")" && pwd)"
 
 echo "=== Hardstop Installer ==="
@@ -21,7 +23,7 @@ echo "      Plugin installed."
 # Step 2: Create skill
 echo "[2/3] Creating skill at: $SKILL_DEST"
 mkdir -p "$SKILL_DEST"
-cat > "$SKILL_DEST/SKILL.md" << 'EOF'
+cat > "$SKILL_DEST/SKILL.md" << EOF
 ---
 name: hs
 version: 1.0.0
@@ -43,13 +45,13 @@ triggers:
 
 **Purpose:** Control the Hardstop pre-execution safety layer that blocks dangerous shell commands.
 
-When the user invokes `/hs` (with optional subcommands), run the appropriate Python command:
+When the user invokes \`/hs\` (with optional subcommands), run the appropriate Python command:
 
-- `/hs` or `/hs status`: `python ~/.claude/plugins/hs/commands/hs_cmd.py status`
-- `/hs on`: `python ~/.claude/plugins/hs/commands/hs_cmd.py on`
-- `/hs off`: `python ~/.claude/plugins/hs/commands/hs_cmd.py off`
-- `/hs skip`: `python ~/.claude/plugins/hs/commands/hs_cmd.py skip`
-- `/hs log`: `python ~/.claude/plugins/hs/commands/hs_cmd.py log`
+- \`/hs\` or \`/hs status\`: \`python $PLUGIN_DEST/commands/hs_cmd.py status\`
+- \`/hs on\`: \`python $PLUGIN_DEST/commands/hs_cmd.py on\`
+- \`/hs off\`: \`python $PLUGIN_DEST/commands/hs_cmd.py off\`
+- \`/hs skip\`: \`python $PLUGIN_DEST/commands/hs_cmd.py skip\`
+- \`/hs log\`: \`python $PLUGIN_DEST/commands/hs_cmd.py log\`
 EOF
 echo "      Skill created."
 
@@ -77,12 +79,12 @@ if 'PreToolUse' not in settings['hooks']:
 # Add Bash hook
 settings['hooks']['PreToolUse'].append({
     'matcher': 'Bash',
-    'hooks': [{'type': 'command', 'command': 'python ~/.claude/plugins/hs/hooks/pre_tool_use.py', 'timeout': 30}]
+    'hooks': [{'type': 'command', 'command': 'python $PLUGIN_DEST/hooks/pre_tool_use.py', 'timeout': 30}]
 })
 # Add Read hook (v1.3 - secrets protection)
 settings['hooks']['PreToolUse'].append({
     'matcher': 'Read',
-    'hooks': [{'type': 'command', 'command': 'python ~/.claude/plugins/hs/hooks/pre_read.py', 'timeout': 30}]
+    'hooks': [{'type': 'command', 'command': 'python $PLUGIN_DEST/hooks/pre_read.py', 'timeout': 30}]
 })
 with open(settings_file, 'w') as f:
     json.dump(settings, f, indent=2)
@@ -93,7 +95,7 @@ with open(settings_file, 'w') as f:
         fi
     fi
 else
-    cat > "$SETTINGS_FILE" << 'EOF'
+    cat > "$SETTINGS_FILE" << EOF
 {
   "hooks": {
     "PreToolUse": [
@@ -102,7 +104,7 @@ else
         "hooks": [
           {
             "type": "command",
-            "command": "python ~/.claude/plugins/hs/hooks/pre_tool_use.py",
+            "command": "python $PLUGIN_DEST/hooks/pre_tool_use.py",
             "timeout": 30
           }
         ]
@@ -112,7 +114,7 @@ else
         "hooks": [
           {
             "type": "command",
-            "command": "python ~/.claude/plugins/hs/hooks/pre_read.py",
+            "command": "python $PLUGIN_DEST/hooks/pre_read.py",
             "timeout": 30
           }
         ]

--- a/tests/test_pre_tool_use_coverage.py
+++ b/tests/test_pre_tool_use_coverage.py
@@ -21,10 +21,12 @@ from unittest import TestCase, main as unittest_main
 from unittest.mock import patch, MagicMock
 from io import StringIO
 
-# Add hooks to path
+# Add hooks and commands to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+sys.path.insert(0, str(Path(__file__).parent.parent / "commands"))
 
 import pre_tool_use
+import hs_cmd
 
 
 class TestBlockCommand(TestCase):
@@ -690,6 +692,102 @@ class TestIsAllSafeEdge(TestCase):
 
     def test_whitespace_only(self):
         self.assertTrue(pre_tool_use.is_all_safe("   "))
+
+
+class TestSafePatternsDeriveFromFile(TestCase):
+    """Test that SAFE_PATTERNS are derived from the script's own location."""
+
+    def test_claude_dir_matches_file_location(self):
+        """_CLAUDE_DIR should be derived from __file__, not an env var."""
+        hooks_dir = Path(pre_tool_use.__file__).absolute().parent
+        plugin_dir = hooks_dir.parent  # hs/
+        expected_claude_dir = str(plugin_dir.parent.parent)  # plugins/ -> config dir
+        self.assertEqual(pre_tool_use._CLAUDE_DIR, expected_claude_dir)
+
+    def test_safe_patterns_match_own_commands(self):
+        """Hardstop's own commands should be whitelisted based on actual location."""
+        claude_dir = pre_tool_use._CLAUDE_DIR
+        self.assertTrue(pre_tool_use.check_safe(f"python {claude_dir}/plugins/hs/hooks/pre_tool_use.py"))
+        self.assertTrue(pre_tool_use.check_safe(f"python {claude_dir}/plugins/hs/commands/hs_cmd.py status"))
+        self.assertTrue(pre_tool_use.check_safe(f"cat {claude_dir}/plugins/hs/README.md"))
+        self.assertTrue(pre_tool_use.check_safe(f"grep pattern {claude_dir}/plugins/hs/hooks/pre_tool_use.py"))
+
+    def test_dynamic_patterns_accept_own_path(self):
+        """Each dynamic pattern should match commands at the actual install path.
+
+        check_safe() can't distinguish which pattern matched (cat/grep have
+        generic patterns that shadow the dynamic ones). Test the dynamic
+        patterns directly to verify they work, not just that check_safe passes.
+        """
+        claude_dir = pre_tool_use._CLAUDE_DIR
+        escaped_dir = pre_tool_use._CLAUDE_DIR_RE
+        dynamic_patterns = [
+            p for p in pre_tool_use.SAFE_PATTERNS
+            if escaped_dir in p
+        ]
+        self.assertEqual(len(dynamic_patterns), 3,
+                         "Expected 3 dynamic patterns (python, cat, grep)")
+        # Each pattern should match at least one command at the actual path
+        own_cmds = [
+            f"python {claude_dir}/plugins/hs/hooks/pre_tool_use.py",
+            f"cat {claude_dir}/plugins/hs/README.md",
+            f"grep pattern {claude_dir}/plugins/hs/hooks/pre_tool_use.py",
+        ]
+        for pattern in dynamic_patterns:
+            matched = any(
+                __import__('re').search(pattern, cmd) for cmd in own_cmds
+            )
+            self.assertTrue(matched,
+                f"Dynamic pattern should match at least one own-path command: {pattern}")
+
+    def test_dynamic_patterns_reject_foreign_path(self):
+        """Each dynamic pattern should reject commands at unrelated paths."""
+        escaped_dir = pre_tool_use._CLAUDE_DIR_RE
+        dynamic_patterns = [
+            p for p in pre_tool_use.SAFE_PATTERNS
+            if escaped_dir in p
+        ]
+        foreign_cmds = [
+            "python /some/other/path/plugins/hs/hooks/pre_tool_use.py",
+            "cat /some/other/path/plugins/hs/README.md",
+            "grep pattern /some/other/path/plugins/hs/hooks/pre_tool_use.py",
+        ]
+        for pattern in dynamic_patterns:
+            for cmd in foreign_cmds:
+                self.assertNotRegex(cmd, pattern,
+                    f"Dynamic pattern should not match foreign path: {cmd}")
+
+    def test_python_at_wrong_path_rejected_by_check_safe(self):
+        """python at a foreign path should be rejected by check_safe().
+
+        Unlike cat/grep which have generic safe patterns that match any
+        non-credential cat or any grep, python has no generic allowlist.
+        So check_safe() is the behavioral test for rejection here.
+        """
+        self.assertFalse(pre_tool_use.check_safe(
+            "python /some/other/path/plugins/hs/hooks/pre_tool_use.py"))
+        self.assertFalse(pre_tool_use.check_safe(
+            "python /some/other/path/plugins/hs/commands/hs_cmd.py status"))
+
+
+class TestHsCmdPluginDir(TestCase):
+    """Test that hs_cmd.py derives PLUGIN_DIR from __file__."""
+
+    def test_plugin_dir_matches_file_location(self):
+        """PLUGIN_DIR should point to the plugin root (parent of commands/)."""
+        expected = Path(hs_cmd.__file__).absolute().parent.parent
+        self.assertEqual(hs_cmd.PLUGIN_DIR, expected)
+
+    def test_plugin_json_found(self):
+        """get_version() should find plugin.json via the derived PLUGIN_DIR."""
+        version = hs_cmd.get_version()
+        # When running from the repo, .claude-plugin/plugin.json exists
+        plugin_json = hs_cmd.PLUGIN_DIR / ".claude-plugin" / "plugin.json"
+        if plugin_json.exists():
+            self.assertNotEqual(version, "unknown")
+        else:
+            # Installed layout may differ; just verify it doesn't crash
+            self.assertIsInstance(version, str)
 
 
 class TestSaveStateError(TestCase):

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -4,9 +4,11 @@
 
 set -e
 
-PLUGIN_DEST="$HOME/.claude/plugins/hs"
-SKILL_DEST="$HOME/.claude/skills/hs"
-SETTINGS_FILE="$HOME/.claude/settings.json"
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+CLAUDE_DIR="${CLAUDE_DIR%/}"
+PLUGIN_DEST="$CLAUDE_DIR/plugins/hs"
+SKILL_DEST="$CLAUDE_DIR/skills/hs"
+SETTINGS_FILE="$CLAUDE_DIR/settings.json"
 STATE_DIR="$HOME/.hardstop"
 
 echo "=== Hardstop Uninstaller ==="


### PR DESCRIPTION
## Summary

Claude Code supports [`CLAUDE_CONFIG_DIR`](https://code.claude.com/docs/en/env-vars) for overriding the default `~/.claude` configuration directory. Hardstop currently hardcodes `~/.claude` in all installers, hooks, and commands, so it can't install or run correctly when this variable is set.

### Approach

**Installers** (`bin/install.js`, `install.sh`, `install.ps1`, `uninstall.sh`) resolve `CLAUDE_CONFIG_DIR` at install time, falling back to `~/.claude`.

**Runtime Python files** (`hooks/pre_tool_use.py`, `commands/hs_cmd.py`) derive their location from `__file__` rather than re-resolving the env var. Since the installer writes absolute paths into `settings.json` and the skill file, the runtime scripts already know where they live on disk. This avoids duplicating normalization logic across languages and handles edge cases (env var not propagated to subprocesses) more robustly.

### Changes

- **`bin/install.js`**: Resolve `CLAUDE_CONFIG_DIR` with tilde expansion and trailing slash stripping; rewrite paths in installed skill file
- **`install.sh`** / **`uninstall.sh`**: Use `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`
- **`install.ps1`**: Use `$env:CLAUDE_CONFIG_DIR` with fallback
- **`hooks/pre_tool_use.py`**: Derive config dir from `__file__` for safe-command whitelist regexes
- **`commands/hs_cmd.py`**: Derive plugin dir from `__file__` for version lookup
- **`tests/`**: 7 new tests for path derivation and safe-pattern matching (the dynamic safe patterns were previously untested)

No behavior change when `CLAUDE_CONFIG_DIR` is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)